### PR TITLE
Add GitHub action for running flake8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: lint
+
+on:
+  push:
+    branches: master
+  pull_request:
+
+jobs:
+  flake8:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        make flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,6 @@ jobs:
           branch_pattern: master
 
     - env:
-        - CMD=flake8
-
-    - env:
         - CMD=pylint
 
     - env:


### PR DESCRIPTION
Add .github/workflows/lint.yml, which lists the GitHub actions, which we
will use for linting. (We may have more linting actions in the same
file, for example pylint, or more actions is separate files)

Inside the file, define `flake8` job, which does the bare minimum
to run flake8 on our codebase:
- checkout the code
- install python
- install flake8
- run flake8

This takes ~23 seconds, compared to the ~3 minutes it takes Travis CI to
run the flake8 task. The difference is that Travis does much more
prerequisites, like installing additional dependencies, which we
don't need in this case.